### PR TITLE
Persisting avatars crash

### DIFF
--- a/lib/src/parts/top.dart
+++ b/lib/src/parts/top.dart
@@ -78,7 +78,7 @@ class Top implements AvataaarPart {
   ///Transform from map to [Top]
   factory Top.fromMap(Map<String, dynamic> map) {
     return Top(
-      topType: Converter.enumFromJson(TopType.values, map['topType'])!,
+      topType: Converter.enumFromJson(TopType.values, map['topType']),
       accessoriesType: Converter.enumFromJson(
           AccessoriesType.values, map['accessoriesType']),
       hatColor: Converter.enumFromJson(HatColor.values, map['hatColor']),


### PR DESCRIPTION
When using persisting avatars, it had an error
```dart
E/flutter (12446): [ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: type '() => TopType?' is not a subtype of type '(() => TopType)?' of 'orElse'
```
To repoduce this juste put this in the main:
```dart
Avataaar.fromMap(Avataaar.random().toMap());
```

This is a good fix because now it work xD